### PR TITLE
Add proxy to the backend plugin

### DIFF
--- a/headlamp-backend/src/plugin.ts
+++ b/headlamp-backend/src/plugin.ts
@@ -61,7 +61,7 @@ export const headlampPlugin = createBackendPlugin({
           }),
         );
         httpRouter.addAuthPolicy({
-          path: '/health',
+          path: '/',
           allow: 'unauthenticated',
         });
       },

--- a/headlamp/src/api/HeadlampClient.ts
+++ b/headlamp/src/api/HeadlampClient.ts
@@ -10,7 +10,7 @@ export class HeadlampClient implements HeadlampApi {
     this.fetchApi = options.fetchApi;
   }
 
-  private async getBaseUrl() {
+  async getBaseUrl() {
     return await this.discoveryApi.getBaseUrl('headlamp');
   }
 
@@ -40,7 +40,7 @@ export class HeadlampClient implements HeadlampApi {
     });
   }
 
-  async health(): Promise<{ status: string }> {
+  async health(): Promise<{ status: string; serverRunning: boolean }> {
     const baseUrl = await this.getBaseUrl();
     const response = await this.fetchApi.fetch(`${baseUrl}/health`);
     return await response.json();

--- a/headlamp/src/api/types.ts
+++ b/headlamp/src/api/types.ts
@@ -1,9 +1,10 @@
 import { createApiRef } from '@backstage/core-plugin-api';
 
 export interface HeadlampApi {
+  getBaseUrl(): Promise<string>;
   startServer(auth: {[key: string]: string}): Promise<void>;
   refreshKubeconfig(auth: {[key: string]: string}): Promise<void>;
-  health(): Promise<{ status: string }>;
+  health(): Promise<{ status: string , serverRunning: boolean}>;
 }
 
 export const headlampApiRef = createApiRef<HeadlampApi>({

--- a/headlamp/src/components/HeadlampComponent/HeadlampComponent.tsx
+++ b/headlamp/src/components/HeadlampComponent/HeadlampComponent.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Progress } from '@backstage/core-components';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useApi, identityApiRef } from '@backstage/core-plugin-api';
 import { headlampApiRef } from '../../api/types';
 import { kubernetesApiRef,kubernetesAuthProvidersApiRef } from '@backstage/plugin-kubernetes-react';
 
@@ -21,13 +21,14 @@ interface HeadlampMessage {
 export function HeadlampComponent() {
   const config = useApi(configApiRef);
   const headlampApi = useApi(headlampApiRef);
-  const [isLoaded, setIsLoaded] = useState(false);
   const refreshInterval = 5000;
   const [isStandalone, setIsStandalone] = useState(true);
-
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [serverRunning, setServerRunning] = useState(false);
+  const [serverStarted, setServerStarted] = useState(false);
+  const [iframeUrlReady, setIframeUrlReady] = useState(false);
   const kubernetesApi = useApi(kubernetesApiRef);
   const kubernetesAuthProvidersApi = useApi(kubernetesAuthProvidersApiRef);
-
 
   const fetchAuthTokenMap = async () => {
     const clusters = await kubernetesApi.getClusters();
@@ -48,57 +49,75 @@ export function HeadlampComponent() {
   }
 
   // Check if Headlamp is running standalone or not
-  // if not, start the server
   useEffect(() => {
     const checkHealth = async () => {
       const res = await headlampApi.health();
       const standalone = res?.status !== 'ok';
       setIsStandalone(standalone);
-      
-      if (!standalone) {
-        const authTokenMap = await fetchAuthTokenMap();
-
-        console.log('Starting Headlamp server');
-        headlampApi.startServer(authTokenMap);
-      }
     };
 
     checkHealth();
   }, [headlampApi]);
 
+  const checkServerRunning = async () => {
+    const res = await headlampApi.health();
+    setServerRunning(res?.serverRunning);
+  }
 
-  const headlampUrl =
-    config.getOptionalString('headlamp.url') ||
-    `${window.location.protocol}//${window.location.hostname}:4466`;
-  const navigate = useNavigate();
-  const location = useLocation();
-
-  /**
-   * Checks if the Headlamp server is ready by making a fetch request.
-   * Sets the component as loaded if the server responds successfully.
-   */
+  // Start server if not standalone
   useEffect(() => {
-    const checkHeadlampReady = async () => {
-      try {
-        const response = await fetch(`${headlampUrl}`);
-        if (response.ok) {
-          setIsLoaded(true);
-        } else {
-          throw new Error(`Headlamp not ready: ${response.statusText}`);
+    const startServer = async () => {
+      if (!isStandalone && !serverStarted) {
+        const authTokenMap = await fetchAuthTokenMap();
+        await headlampApi.startServer(authTokenMap);
+        setServerStarted(true);
+      }
+    }
+    startServer();
+  }, [isStandalone, serverStarted]);
+
+  // Check server status only after server has been started
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+    
+    const checkServerStatus = async () => {
+      if (!serverRunning) {
+        await checkServerRunning();
+        if (!serverRunning) {
+          timeoutId = setTimeout(checkServerStatus, refreshInterval);
         }
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error('Failed to check Headlamp readiness:', err);
       }
     };
 
-    if (!isLoaded) {
-      checkHeadlampReady();
-      const timer = setInterval(checkHeadlampReady, refreshInterval);
-      return () => clearInterval(timer);
+    if (!isStandalone && serverStarted && !serverRunning) {
+      checkServerStatus();
     }
-    return undefined;
-  }, [isLoaded, headlampUrl]);
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [isStandalone, serverStarted, serverRunning]);
+
+  const [headlampUrl, setHeadlampUrl] = useState('');
+  const [iframeSrc, setIframeSrc] = useState('');
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const initUrl = async () => {
+      const baseUrl = await headlampApi.getBaseUrl();
+      const url = config.getOptionalString('headlamp.url') || (baseUrl.endsWith('/') ? baseUrl : baseUrl + '/');
+      setHeadlampUrl(url);
+    };
+    initUrl();
+  }, [config]);
+
+  useEffect(() => {
+    const queryParams = new URLSearchParams(location.search).toString();
+    setIframeSrc(queryParams ? `${headlampUrl}?${queryParams}` : headlampUrl);
+  }, [headlampUrl, location.search]);
 
   /**
    * Handles messages received from the Headlamp server.
@@ -145,15 +164,113 @@ export function HeadlampComponent() {
     return undefined;
   }, [isStandalone, headlampApi]);
 
-  if (!isLoaded) {
+  const identityApi = useApi(identityApiRef);
+  useEffect(() => {
+    let pollInterval: NodeJS.Timeout;
+    
+    const syncToken = async () => {
+      console.log('Syncing token');
+      try{
+        const {token} = await identityApi.getCredentials();
+        if (!token || !iframeRef.current) return;
+
+        // Post the token to the iframe
+        iframeRef.current.contentWindow?.postMessage({
+          type: 'BACKSTAGE_AUTH_TOKEN', payload: {token},
+        }, new URL(iframeSrc).origin)
+
+        console.log('Token posted to iframe');
+
+      } catch (error){
+        console.error('Error syncing token', error);
+      }
+    }
+
+    // Only start token syncing if server is running
+    if (serverRunning && iframeRef.current) {
+      // Initial sync when iframe loads
+      iframeRef.current.addEventListener('load', syncToken);
+
+      syncToken();
+      // Set up polling for token changes
+      let previousToken = '';
+      pollInterval = setInterval(async () => {
+        try {
+          const {token} = await identityApi.getCredentials();
+          if (token && token !== previousToken) {
+            previousToken = token;
+            syncToken();
+          }
+        } catch (error) {
+          console.error('Error checking token', error);
+        }
+      }, refreshInterval);
+    }
+
+    return () => {
+      if (pollInterval) {
+        clearInterval(pollInterval);
+      }
+      if (iframeRef.current) {
+        iframeRef.current.removeEventListener('load', syncToken);
+      }
+    };
+  }, [identityApi, iframeSrc, serverRunning,iframeUrlReady]);
+
+  // Check if the iframe URL is responding with valid HTML
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+
+    const checkIframeUrl = async () => {
+      if (iframeSrc && !iframeUrlReady) {
+        try {
+          const response = await fetch(iframeSrc);
+          if (response.ok && response.headers.get('content-type')?.includes('text/html')) {
+            setIframeUrlReady(true);
+            // Clear any existing timeout since we're ready
+            if (timeoutId) {
+              clearTimeout(timeoutId);
+            }
+          } else {
+            // If not ready, check again after interval
+            timeoutId = setTimeout(checkIframeUrl, refreshInterval);
+          }
+        } catch (error) {
+          console.error('Error checking iframe URL:', error);
+          // If error occurs, check again after interval
+          timeoutId = setTimeout(checkIframeUrl, refreshInterval);
+        }
+      }
+    };
+
+    // Only start checking if we have a URL and it's not ready yet
+    if (iframeSrc && !iframeUrlReady) {
+      checkIframeUrl();
+    }
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [iframeSrc, iframeUrlReady, refreshInterval]);
+
+  // Show loading in these cases:
+  // 1. Not standalone and server not started yet
+  // 2. Not standalone and server started but not running yet
+  // 3. URL or iframeSrc not initialized yet
+  // 4. Iframe URL not responding with valid HTML yet
+  if ((!isStandalone && (!serverStarted || !serverRunning)) || 
+      !headlampUrl || 
+      !iframeSrc || 
+      !iframeUrlReady) {
     return <Progress />;
   }
 
-  const queryParams = new URLSearchParams(location.search).toString();
-  const iframeSrc = queryParams ? `${headlampUrl}?${queryParams}` : headlampUrl;
-
+  // Only render iframe when server is running, URLs are set, and iframe URL is responding
   return (
     <iframe
+      ref={iframeRef}
       src={iframeSrc}
       title="Headlamp"
       style={{


### PR DESCRIPTION
This change implements an authenticated proxy in the backend handles routing of requests to Headlamp frontend and backend and the proxy url is used in the frontend iframe thus allows users to deploy the plugin without having to expose the headlamp server port (:4466)