### PR TITLE
Fix auth tokens map for OIDC auth providers

### DIFF
--- a/headlamp/package.json
+++ b/headlamp/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@backstage/core-components": "^0.14.10",
     "@backstage/core-plugin-api": "^1.10.2",
+    "@backstage/plugin-kubernetes-common": "^0.9.4",
     "@backstage/plugin-kubernetes-react": "^0.5.2",
     "@backstage/theme": "^0.5.1",
     "@material-ui/core": "^4.9.13",

--- a/headlamp/src/api/HeadlampClient.ts
+++ b/headlamp/src/api/HeadlampClient.ts
@@ -1,4 +1,5 @@
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+import { KubernetesRequestAuth } from '@backstage/plugin-kubernetes-common';
 import { HeadlampApi } from './types';
 
 export class HeadlampClient implements HeadlampApi {
@@ -14,7 +15,7 @@ export class HeadlampClient implements HeadlampApi {
     return await this.discoveryApi.getBaseUrl('headlamp');
   }
 
-  async startServer(auth: {[key: string]: string}): Promise<void> {
+  async startServer(auth: KubernetesRequestAuth): Promise<void> {
     const baseUrl = await this.getBaseUrl();
     await this.fetchApi.fetch(`${baseUrl}/start`, {
       method: 'POST',
@@ -27,7 +28,7 @@ export class HeadlampClient implements HeadlampApi {
     });
   }
 
-  async refreshKubeconfig(auth: {[key: string]: string}): Promise<void> {
+  async refreshKubeconfig(auth: KubernetesRequestAuth): Promise<void> {
     const baseUrl = await this.getBaseUrl();
     await this.fetchApi.fetch(`${baseUrl}/refreshKubeconfig`, {
       method: 'POST',

--- a/headlamp/src/api/types.ts
+++ b/headlamp/src/api/types.ts
@@ -1,8 +1,9 @@
 import { createApiRef } from '@backstage/core-plugin-api';
+import { KubernetesRequestAuth } from '@backstage/plugin-kubernetes-common';
 
 export interface HeadlampApi {
-  startServer(auth: {[key: string]: string}): Promise<void>;
-  refreshKubeconfig(auth: {[key: string]: string}): Promise<void>;
+  startServer(auth: KubernetesRequestAuth): Promise<void>;
+  refreshKubeconfig(auth: KubernetesRequestAuth): Promise<void>;
   health(): Promise<{ status: string }>;
 }
 

--- a/headlamp/yarn.lock
+++ b/headlamp/yarn.lock
@@ -1158,6 +1158,16 @@
     ajv "^8.10.0"
     lodash "^4.17.21"
 
+"@backstage/catalog-model@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-model/-/catalog-model-1.7.3.tgz#c74f680cbdbe4209a4a9c17de34b1949f1d19a2d"
+  integrity sha512-eqSRo7briHyVXMBkNdgQ8rdrw5W2LZifqrIabGwjcvoV8YDG2hFBuCPfqpdpfsgeCIk45iyXilTi9rg1Nt1fgw==
+  dependencies:
+    "@backstage/errors" "^1.2.7"
+    "@backstage/types" "^1.2.1"
+    ajv "^8.10.0"
+    lodash "^4.17.21"
+
 "@backstage/cli-common@^0.1.13", "@backstage/cli-common@^0.1.14":
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/@backstage/cli-common/-/cli-common-0.1.14.tgz#2291520acfbac860a05dd48fc3b876d5cd789b76"
@@ -1330,6 +1340,15 @@
   dependencies:
     "@backstage/errors" "^1.2.6"
     "@backstage/types" "^1.2.0"
+    ms "^2.1.3"
+
+"@backstage/config@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.3.2.tgz#ddea2f7646fba459316566dad770af9265dd1241"
+  integrity sha512-9na5EAf5AJzrwAysnIbNqFmPN1ES9IiUwy9uGMhwFzxXeHjDz+RAmiqFYFL6tNMwuFwrW1zxpvzKAUXvvYDe6Q==
+  dependencies:
+    "@backstage/errors" "^1.2.7"
+    "@backstage/types" "^1.2.1"
     ms "^2.1.3"
 
 "@backstage/core-app-api@^1.12.0", "@backstage/core-app-api@^1.15.1":
@@ -1543,6 +1562,14 @@
     "@backstage/types" "^1.2.0"
     serialize-error "^8.0.1"
 
+"@backstage/errors@^1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@backstage/errors/-/errors-1.2.7.tgz#6da0251d78192328e1b7893420b92aec90df5aad"
+  integrity sha512-XsH0w4hW0aJs3NuANbvgpQoKrQGYIMUaVKeDoGO/99uDgBbJ2QyDb/m9onbKV7tG9HkEe/NKixKqRhxRLx4wzA==
+  dependencies:
+    "@backstage/types" "^1.2.1"
+    serialize-error "^8.0.1"
+
 "@backstage/eslint-plugin@^0.1.5":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@backstage/eslint-plugin/-/eslint-plugin-0.1.10.tgz#8f786ccc3c315dfe9b1cd3aa6d8435fd266a0574"
@@ -1702,6 +1729,19 @@
     lodash "^4.17.21"
     luxon "^3.0.0"
 
+"@backstage/plugin-kubernetes-common@^0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-kubernetes-common/-/plugin-kubernetes-common-0.9.4.tgz#02cd7d3a7c7a07dffc18dab2ad5fb2018d09e7bd"
+  integrity sha512-XyUMmLHLX6ZweIFPEWu/vft1tY0A1dLzd3vOlcxRCvYw2MmLTrKVgTocdu/jItSAN7hNeWhZJ7kqO6pYMbHZgw==
+  dependencies:
+    "@backstage/catalog-model" "^1.7.3"
+    "@backstage/plugin-permission-common" "^0.8.4"
+    "@backstage/types" "^1.2.1"
+    "@kubernetes/client-node" "1.0.0-rc7"
+    kubernetes-models "^4.3.1"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+
 "@backstage/plugin-kubernetes-react@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-kubernetes-react/-/plugin-kubernetes-react-0.5.2.tgz#79d1116e33450fb31aaa767d0fb597336ef59708"
@@ -1750,6 +1790,19 @@
     "@backstage/config" "^1.3.1"
     "@backstage/errors" "^1.2.6"
     "@backstage/types" "^1.2.0"
+    cross-fetch "^4.0.0"
+    uuid "^11.0.0"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.20.4"
+
+"@backstage/plugin-permission-common@^0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.8.4.tgz#9f9a166041853833b50e844bbe35a2d9b9aca37f"
+  integrity sha512-zZSfXadycRCP/YG2Cf4p/hxDU4fhrYDAVneo9PKZMfy3O4ERdtrYehGuOspcak2NkeMmaj2KfsFuWFuWK2xBTQ==
+  dependencies:
+    "@backstage/config" "^1.3.2"
+    "@backstage/errors" "^1.2.7"
+    "@backstage/types" "^1.2.1"
     cross-fetch "^4.0.0"
     uuid "^11.0.0"
     zod "^3.22.4"
@@ -1834,6 +1887,11 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.2.0.tgz#14fec6240e7ec0f3189fca0890be1e54debc54ea"
   integrity sha512-YoWvCLJNOgvRXSqH8EoWmmQ8G8+emiYpn5dqDZcMrqAA6Xa8yFFVsQTujEusx5ZSwahPMbSDobNJgiSoXL3XyA==
+
+"@backstage/types@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.2.1.tgz#8c15c71e6b629806d3dc00227aaa4fd1c19cef16"
+  integrity sha512-0GkrZthoIkUzoeop+8fZZk2MWlLd1q0LB59tMarsjw7ccMtFYR96jhlf1qGvcbw7Gn5ETtJfTC2C1aUzvgvF+w==
 
 "@backstage/version-bridge@^1.0.10", "@backstage/version-bridge@^1.0.8":
   version "1.0.10"


### PR DESCRIPTION
I tried to use this plugin in the Backstage instance connected to several Kubernetes clusters with OIDC authentication and encountered a problem.
```
2025-04-15T12:31:06.532Z headlamp info Headlamp Server already running, refreshing kubeconfig 
2025-04-15T12:31:06.532Z headlamp error Error starting Headlamp Server: Error: Auth token not found under oidc.oidc-cluster-a in request body 
2025-04-15T12:31:06.533Z rootHttpRouter info [2025-04-15T12:31:06.533Z] "POST /api/headlamp/start HTTP/1.1" 500 49 "http://localhost:3000/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36" type="incomingRequest" date="2025-04-15T12:31:06.533Z" method="POST" url="/api/headlamp/start" status=500 httpVersion="1.1" userAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36" contentLength=49 referrer="http://localhost:3000/"
2025-04-15T12:31:06.533Z headlamp error Error refreshing kubeconfig: Error: Auth token not found under oidc.oidc-cluster-a in request body 
2025-04-15T12:31:06.534Z rootHttpRouter info [2025-04-15T12:31:06.534Z] "POST /api/headlamp/refreshKubeconfig HTTP/1.1" 500 46 "http://localhost:3000/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36" type="incomingRequest" date="2025-04-15T12:31:06.534Z" method="POST" url="/api/headlamp/refreshKubeconfig" status=500 httpVersion="1.1" userAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36" contentLength=46 referrer="http://localhost:3000/"
```

The issue is with the format of the OIDC authentication tokens being sent from the frontend plugin. The current format is:
```
{
  [authProvider: string]: string;
}
```
which doesn't work for OIDC providers. The OIDC strategy [called from the backend plugin](https://github.com/headlamp-k8s/backstage-plugin/blob/main/headlamp-backend/src/headlamp.ts#L52-L55) expects authentication tokens in the following format ([source](https://github.com/backstage/backstage/blob/master/plugins/kubernetes-backend/src/auth/OidcStrategy.ts#L46)):
```
{
  oidc: {
    [oidcTokenProvider: string]: string;
  }
}
```
In this PR, I aligned the format of the authentication tokens map on the frontend to match the format expected by different authentication strategies on the backend.